### PR TITLE
Store ssh keys in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@ github-heroku-pusher does pretty much what sounds like it does. It takes a githu
 
 Setup
 =====
-In order for the pusher to run, we need to get these four variables:
+
+In order for the pusher to run, we need to set these six variables:
+
+But first, generate a keypair with `ssh-keygen -t rsa -f ~/path/to/a/tmp-dir/id_rsa 2>&1`
 
 *   HEROKU_USERNAME
 *   HEROKU\_API_KEY (Found at the bottom of the [account page](https://api.heroku.com/account))
-*   GITHUB_REPO (Example: https://github.com/ajlai/Test)
+*   GITHUB_REPO (Example: git@github.com:ajlai/Test.git)
 *   HEROKU_REPO (Example: git@heroku.com:smooth-sword-2980.git)
+*   PUBLIC_KEY (contents of the id_rsa.pub file generated above)
+*   PRIVATE_KEY (contents of the id_rsa file generated above)
 
 Next, we can set up the app in Heroku:
 

--- a/lib/heroku.rb
+++ b/lib/heroku.rb
@@ -7,7 +7,18 @@ Heroku::Auth.instance_eval do
   key_path = "#{home_directory}/.ssh/id_rsa.pub"
   if available_ssh_public_keys.empty?
     puts "Generating New Pair"
-    generate_ssh_key("id_rsa")
+
+    ssh_dir = File.join(home_directory, ".ssh")
+    unless File.exists?(ssh_dir)
+      FileUtils.mkdir_p ssh_dir
+      unless running_on_windows?
+        File.chmod(0700, ssh_dir)
+      end
+    end
+
+    File.open(key_path, 'w') {|f| f.write(ENV['PUBLIC_KEY']) }
+    File.open(key_path[0..-5], 'w') {|f| f.write(ENV['PRIVATE_KEY']) }
+
     associate_key(key_path)
   end
   ::CURRENT_SSH_KEY = File.read(key_path)


### PR DESCRIPTION
Store the ssh keys in environment variables to avoid unnecessary regenerations when running on a single Heroku dyno.
Heroku shuts down inactive apps and when they restart on a request (from github) the keys are regenerated and therefore not the same key that has been added as a deploy key to the github repo.
